### PR TITLE
Feat: 회원 가입, 로그인 API 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,8 @@ import { MorganInterceptor, MorganModule } from "nest-morgan";
 import { Account } from "./domain/entities/account.entity";
 import { History } from "./domain/entities/history.entity";
 import { User } from "./domain/entities/user.entity";
+import { AuthModule } from "./domain/auth/auth.module";
+import { UserModule } from "./domain/user/user.module";
 
 @Module({
 	imports: [
@@ -28,7 +30,9 @@ import { User } from "./domain/entities/user.entity";
 			entities: [User, History, Account]
 			// synchronize: true
 		}),
-		MorganModule
+		MorganModule,
+		AuthModule,
+		UserModule
 	],
 	providers: [
 		{

--- a/src/domain/auth/auth.jwtStrategy.ts
+++ b/src/domain/auth/auth.jwtStrategy.ts
@@ -1,0 +1,17 @@
+import { PassportStrategy } from "@nestjs/passport";
+import { ExtractJwt, Strategy } from "passport-jwt";
+
+export class JwtStrategy extends PassportStrategy(Strategy) {
+	constructor() {
+		console.log(process.env.SECRET_KEY);
+		super({
+			jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+			ignoreExpiration: false,
+			secretOrKey: process.env.SECRET_KEY
+		});
+	}
+
+	async validate(payload: any) {
+		return { userId: payload.userId, userName: payload.userName };
+	}
+}

--- a/src/domain/auth/auth.localStrategy.ts
+++ b/src/domain/auth/auth.localStrategy.ts
@@ -1,0 +1,19 @@
+import { Injectable } from "@nestjs/common";
+import { PassportStrategy } from "@nestjs/passport";
+import { Strategy } from "passport-local";
+import { AuthService } from "./auth.service";
+
+@Injectable()
+export class LocalStrategy extends PassportStrategy(Strategy) {
+	constructor(private authService: AuthService) {
+		super({ usernameField: "userId" });
+	}
+
+	async validate(userId: string, password: string) {
+		const user = this.authService.validateUser(userId, password);
+		if (!user) {
+			return null;
+		}
+		return user;
+	}
+}

--- a/src/domain/auth/auth.module.ts
+++ b/src/domain/auth/auth.module.ts
@@ -1,0 +1,28 @@
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
+import { JwtModule } from "@nestjs/jwt";
+import { PassportModule } from "@nestjs/passport";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { User } from "../entities/user.entity";
+import { UserRepository } from "../user/user.repository";
+import { JwtStrategy } from "./auth.jwtStrategy";
+import { LocalStrategy } from "./auth.localStrategy";
+import { AuthService } from "./auth.service";
+
+@Module({
+	imports: [
+		ConfigModule.forRoot({
+			envFilePath: [".env"],
+			isGlobal: true
+		}),
+		PassportModule,
+		TypeOrmModule.forFeature([User, UserRepository]),
+		JwtModule.register({
+			secret: process.env.SECRET_KEY,
+			signOptions: { expiresIn: "1D" }
+		})
+	],
+	providers: [AuthService, LocalStrategy, JwtStrategy],
+	exports: [AuthService]
+})
+export class AuthModule {}

--- a/src/domain/auth/auth.service.spec.ts
+++ b/src/domain/auth/auth.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { AuthService } from "./auth.service";
+
+describe("AuthService", () => {
+	let service: AuthService;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [AuthService]
+		}).compile();
+
+		service = module.get<AuthService>(AuthService);
+	});
+
+	it("should be defined", () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/src/domain/auth/auth.service.ts
+++ b/src/domain/auth/auth.service.ts
@@ -3,6 +3,7 @@ import { JwtService } from "@nestjs/jwt";
 import { UserRepository } from "../user/user.repository";
 import * as bcrypt from "bcrypt";
 import { User } from "../entities/user.entity";
+import { UnauthorizedUserException } from "../user/exception/UnauthorizedUserException";
 
 @Injectable()
 export class AuthService {
@@ -13,19 +14,16 @@ export class AuthService {
 
 	async validateUser(userId: string, password: string) {
 		const user = await this.userRepository.findUser(userId);
-
 		if (
 			!user ||
 			(user && !(await bcrypt.compare(password, user.password)))
 		) {
-			throw new Error(); // UserUnauthorizedException
+			throw new UnauthorizedUserException();
 		}
-
 		return user;
 	}
 
 	makeToken(user: User) {
-		console.log(user);
 		const payload = { userId: user.userId, userName: user.userName };
 		return this.jwtService.sign(payload);
 	}

--- a/src/domain/auth/auth.service.ts
+++ b/src/domain/auth/auth.service.ts
@@ -1,0 +1,32 @@
+import { Injectable } from "@nestjs/common";
+import { JwtService } from "@nestjs/jwt";
+import { UserRepository } from "../user/user.repository";
+import * as bcrypt from "bcrypt";
+import { User } from "../entities/user.entity";
+
+@Injectable()
+export class AuthService {
+	constructor(
+		private userRepository: UserRepository,
+		private jwtService: JwtService
+	) {}
+
+	async validateUser(userId: string, password: string) {
+		const user = await this.userRepository.findUser(userId);
+
+		if (
+			!user ||
+			(user && !(await bcrypt.compare(password, user.password)))
+		) {
+			throw new Error(); // UserUnauthorizedException
+		}
+
+		return user;
+	}
+
+	makeToken(user: User) {
+		console.log(user);
+		const payload = { userId: user.userId, userName: user.userName };
+		return this.jwtService.sign(payload);
+	}
+}

--- a/src/domain/auth/guards/jwtGuard.guard.ts
+++ b/src/domain/auth/guards/jwtGuard.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+
+@Injectable()
+export class JwtGuard extends AuthGuard("jwt") {}

--- a/src/domain/auth/guards/localAuthGuard.guard.ts
+++ b/src/domain/auth/guards/localAuthGuard.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from "@nestjs/common";
+import { AuthGuard } from "@nestjs/passport";
+
+@Injectable()
+export class LocalAuthGuard extends AuthGuard("local") {}

--- a/src/domain/user/dto/createUser.dto.ts
+++ b/src/domain/user/dto/createUser.dto.ts
@@ -1,0 +1,15 @@
+import { IsNotEmpty, IsString, Length } from "class-validator";
+
+export class CreateUserDto {
+	@IsString()
+	@IsNotEmpty()
+	userId!: string;
+
+	@IsString()
+	@IsNotEmpty()
+	password!: string;
+
+	@IsString()
+	@IsNotEmpty()
+	userName!: string;
+}

--- a/src/domain/user/dto/createUser.dto.ts
+++ b/src/domain/user/dto/createUser.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsString, Length } from "class-validator";
+import { IsNotEmpty, IsString } from "class-validator";
 
 export class CreateUserDto {
 	@IsString()

--- a/src/domain/user/dto/responseToken.dto.ts
+++ b/src/domain/user/dto/responseToken.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from "class-validator";
+
+export class ResponseTokenDto {
+	@IsString()
+	@IsNotEmpty()
+	token!: string;
+}

--- a/src/domain/user/exception/DuplicatedUserException.ts
+++ b/src/domain/user/exception/DuplicatedUserException.ts
@@ -1,0 +1,8 @@
+import { HttpException, HttpStatus } from "@nestjs/common";
+import { ErrorCode } from "src/global/common/ErrorCode";
+
+export class DuplicatedUserException extends HttpException {
+	constructor() {
+		super(ErrorCode.DuplicatedUser, HttpStatus.CONFLICT);
+	}
+}

--- a/src/domain/user/exception/UnauthorizedUserException.ts
+++ b/src/domain/user/exception/UnauthorizedUserException.ts
@@ -1,0 +1,8 @@
+import { HttpException, HttpStatus } from "@nestjs/common";
+import { ErrorCode } from "src/global/common/ErrorCode";
+
+export class UnauthorizedUserException extends HttpException {
+	constructor() {
+		super(ErrorCode.UnauthorizedUser, HttpStatus.NOT_FOUND);
+	}
+}

--- a/src/domain/user/user.controller.spec.ts
+++ b/src/domain/user/user.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { UserController } from "./user.controller";
+
+describe("UserController", () => {
+	let controller: UserController;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			controllers: [UserController]
+		}).compile();
+
+		controller = module.get<UserController>(UserController);
+	});
+
+	it("should be defined", () => {
+		expect(controller).toBeDefined();
+	});
+});

--- a/src/domain/user/user.controller.ts
+++ b/src/domain/user/user.controller.ts
@@ -1,9 +1,19 @@
-import { Body, Controller, Post, Request, UseGuards } from "@nestjs/common";
+import {
+	Body,
+	ClassSerializerInterceptor,
+	Controller,
+	Post,
+	Request,
+	UseGuards,
+	UseInterceptors
+} from "@nestjs/common";
 import { AuthService } from "../auth/auth.service";
 import { LocalAuthGuard } from "../auth/guards/localAuthGuard.guard";
 import { CreateUserDto } from "./dto/createUser.dto";
+import { ResponseTokenDto } from "./dto/responseToken.dto";
 import { UserService } from "./user.service";
 
+@UseInterceptors(ClassSerializerInterceptor)
 @Controller("users")
 export class UserController {
 	constructor(
@@ -12,13 +22,13 @@ export class UserController {
 	) {}
 
 	@Post("signup")
-	async signUp(@Body() body: CreateUserDto) {
+	async signUp(@Body() body: CreateUserDto): Promise<ResponseTokenDto> {
 		return { token: await this.userService.create(body) };
 	}
 
 	@UseGuards(LocalAuthGuard)
 	@Post("signin")
-	async signIn(@Request() req) {
-		return { token: await this.authService.makeToken(req.user) };
+	async signIn(@Request() req): Promise<ResponseTokenDto> {
+		return { token: this.authService.makeToken(req.user) };
 	}
 }

--- a/src/domain/user/user.controller.ts
+++ b/src/domain/user/user.controller.ts
@@ -1,0 +1,24 @@
+import { Body, Controller, Post, Request, UseGuards } from "@nestjs/common";
+import { AuthService } from "../auth/auth.service";
+import { LocalAuthGuard } from "../auth/guards/localAuthGuard.guard";
+import { CreateUserDto } from "./dto/createUser.dto";
+import { UserService } from "./user.service";
+
+@Controller("users")
+export class UserController {
+	constructor(
+		private readonly userService: UserService,
+		private readonly authService: AuthService
+	) {}
+
+	@Post("signup")
+	async signUp(@Body() body: CreateUserDto) {
+		return { token: await this.userService.create(body) };
+	}
+
+	@UseGuards(LocalAuthGuard)
+	@Post("signin")
+	async signIn(@Request() req) {
+		return { token: await this.authService.makeToken(req.user) };
+	}
+}

--- a/src/domain/user/user.module.ts
+++ b/src/domain/user/user.module.ts
@@ -1,0 +1,14 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { AuthModule } from "../auth/auth.module";
+import { User } from "../entities/user.entity";
+import { UserController } from "./user.controller";
+import { UserRepository } from "./user.repository";
+import { UserService } from "./user.service";
+
+@Module({
+	imports: [TypeOrmModule.forFeature([User, UserRepository]), AuthModule],
+	controllers: [UserController],
+	providers: [UserService]
+})
+export class UserModule {}

--- a/src/domain/user/user.repository.ts
+++ b/src/domain/user/user.repository.ts
@@ -1,0 +1,20 @@
+import { EntityRepository, Repository } from "typeorm";
+import { User } from "../entities/user.entity";
+import * as bcrypt from "bcrypt";
+import { CreateUserDto } from "./dto/createUser.dto";
+
+@EntityRepository(User)
+export class UserRepository extends Repository<User> {
+	async findUser(userId: string) {
+		return await this.findOne({ userId });
+	}
+
+	async createUser(createUserDto: CreateUserDto) {
+		const newUser = new User();
+		newUser.userId = createUserDto.userId;
+		newUser.password = await bcrypt.hash(createUserDto.password, 10);
+		newUser.userName = createUserDto.userName;
+
+		return await this.save(newUser);
+	}
+}

--- a/src/domain/user/user.service.spec.ts
+++ b/src/domain/user/user.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { UserService } from "./user.service";
+
+describe("UserService", () => {
+	let service: UserService;
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [UserService]
+		}).compile();
+
+		service = module.get<UserService>(UserService);
+	});
+
+	it("should be defined", () => {
+		expect(service).toBeDefined();
+	});
+});

--- a/src/domain/user/user.service.ts
+++ b/src/domain/user/user.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { AuthService } from "../auth/auth.service";
 import { CreateUserDto } from "./dto/createUser.dto";
+import { DuplicatedUserException } from "./exception/DuplicatedUserException";
 import { UserRepository } from "./user.repository";
 
 @Injectable()
@@ -16,7 +17,7 @@ export class UserService {
 		);
 		console.log(findUser);
 		if (findUser) {
-			throw new Error();
+			throw new DuplicatedUserException();
 		}
 		const user = await this.userRepository.createUser(createUserDto);
 		console.log(user);

--- a/src/domain/user/user.service.ts
+++ b/src/domain/user/user.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from "@nestjs/common";
+import { AuthService } from "../auth/auth.service";
+import { CreateUserDto } from "./dto/createUser.dto";
+import { UserRepository } from "./user.repository";
+
+@Injectable()
+export class UserService {
+	constructor(
+		private userRepository: UserRepository,
+		private authService: AuthService
+	) {}
+
+	async create(createUserDto: CreateUserDto) {
+		const findUser = await this.userRepository.findUser(
+			createUserDto.userId
+		);
+		console.log(findUser);
+		if (findUser) {
+			throw new Error();
+		}
+		const user = await this.userRepository.createUser(createUserDto);
+		console.log(user);
+		return this.authService.makeToken(user);
+	}
+}

--- a/src/global/common/CommonResponse.ts
+++ b/src/global/common/CommonResponse.ts
@@ -1,0 +1,4 @@
+export class CommonResponse {
+	protected statusCode: number;
+	protected message: string;
+}

--- a/src/global/common/ErrorCode.ts
+++ b/src/global/common/ErrorCode.ts
@@ -1,0 +1,26 @@
+export class ErrorCode {
+	static readonly UnAuth = new ErrorCode(401, "인증되지 않은 사용자입니다.");
+	static readonly BadRequest = new ErrorCode(400, "잘못된 접근입니다.");
+	static readonly NotFound = new ErrorCode(
+		404,
+		"요청받은 리소스를 찾을 수 없습니다."
+	);
+	static readonly UnauthorizedUser = new ErrorCode(
+		404,
+		"아이디나 비밀번호를 확인해주세요."
+	);
+	static readonly NewError = new ErrorCode(404, "예상치 못한 에러입니다.");
+	static readonly DuplicatedUser = new ErrorCode(409, "중복된 아이디입니다.");
+	constructor(
+		private readonly statusCode: number,
+		public readonly message: string
+	) {}
+
+	get StatusCode(): number {
+		return this.statusCode;
+	}
+
+	get Message(): string {
+		return this.message;
+	}
+}

--- a/src/global/common/ErrorResponse.ts
+++ b/src/global/common/ErrorResponse.ts
@@ -1,0 +1,14 @@
+import { CommonResponse } from "./CommonResponse";
+import { ErrorCode } from "./ErrorCode";
+
+export class ErrorResponse extends CommonResponse {
+	constructor(errorCode: ErrorCode) {
+		super();
+		this.statusCode = errorCode.StatusCode;
+		this.message = errorCode.Message;
+	}
+
+	public static response(errorCode: ErrorCode) {
+		return new ErrorResponse(errorCode);
+	}
+}

--- a/src/global/exception/ErrorHandler.ts
+++ b/src/global/exception/ErrorHandler.ts
@@ -1,0 +1,51 @@
+import {
+	ArgumentsHost,
+	BadRequestException,
+	ExceptionFilter,
+	NotFoundException,
+	UnauthorizedException
+} from "@nestjs/common";
+import { DuplicatedUserException } from "src/domain/user/exception/DuplicatedUserException";
+import { UnauthorizedUserException } from "src/domain/user/exception/UnauthorizedUserException";
+import { ErrorCode } from "../common/ErrorCode";
+import { ErrorResponse } from "../common/ErrorResponse";
+
+export class ExceptionHandler implements ExceptionFilter {
+	catch(exception: unknown, host: ArgumentsHost) {
+		const ctx = host.switchToHttp();
+		const response = ctx.getResponse();
+
+		if (exception instanceof BadRequestException) {
+			const status = exception.getStatus();
+			response
+				.status(status)
+				.json(ErrorResponse.response(ErrorCode.BadRequest));
+		} else if (exception instanceof NotFoundException) {
+			const status = exception.getStatus();
+			response
+				.status(status)
+				.json(ErrorResponse.response(ErrorCode.NotFound));
+		} else if (exception instanceof UnauthorizedException) {
+			const status = exception.getStatus();
+			response
+				.status(status)
+				.json(ErrorResponse.response(ErrorCode.UnAuth));
+		} else if (exception instanceof DuplicatedUserException) {
+			const status = exception.getStatus();
+			response
+				.status(status)
+				.json(ErrorResponse.response(ErrorCode.DuplicatedUser));
+		} else if (exception instanceof UnauthorizedUserException) {
+			const status = exception.getStatus();
+			response
+				.status(status)
+				.json(ErrorResponse.response(ErrorCode.UnauthorizedUser));
+		} else {
+			// 에러 처리가 완료되면 다른 오류로 교체해주세요.
+			console.log(exception);
+			response
+				.status(417)
+				.json(ErrorResponse.response(ErrorCode.NewError));
+		}
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { ValidationPipe } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
 import { AppModule } from "./app.module";
+import { ExceptionHandler } from "./global/exception/ErrorHandler";
 import { setSwagger } from "./global/swagger/SetSwagger.swagger";
 
 async function bootstrap() {
@@ -13,6 +14,7 @@ async function bootstrap() {
 		})
 	);
 	setSwagger(app);
+	app.useGlobalFilters(new ExceptionHandler());
 	await app.listen(3000);
 }
 bootstrap();


### PR DESCRIPTION
- JWT 이용
- AuthService 작성
- jwtGuard, localAuthGuard 작성

- userController, userService, userRepository 작성


- 회원가입, 로그인 API 응답을 다른 API와 동일한 형태가 될 수 있도록, message, status는 빼고 토큰만 보내줄 수 있도록 처리 (userController 파일 참고)